### PR TITLE
Renaming QG model class

### DIFF
--- a/examples/LambDipole_qg.py
+++ b/examples/LambDipole_qg.py
@@ -12,8 +12,7 @@ import matplotlib.pyplot as plt
 plt.rcParams['contour.negative_linestyle'] = 'dashed'
 import numpy as np
 
-#from CoupledModel import Model
-from niwqg import QGModel as Model
+from niwqg import QGModel
 from niwqg import InitialConditions as ic
 
 plt.close('all')
@@ -37,7 +36,7 @@ tmax = 10*Te
 
 path = "128/lamb/moderate_filter"
 #path = "512/lamb/large_amp"
-m = Model.QGModel(L=L,nx=nx, tmax = tmax,dt = dt, twrite=int(0.1*Te/dt),
+m = QGModel.Model(L=L,nx=nx, tmax = tmax,dt = dt, twrite=int(0.1*Te/dt),
                     nu4=7.5e8, use_filter=False,save_to_disk=False,
                     tsave_snapshots=5,path=path,
                     U =-U, tdiags=1, beta = 0.)

--- a/niwqg/QGModel.py
+++ b/niwqg/QGModel.py
@@ -7,7 +7,7 @@ import logging, os
 from .Diagnostics import *
 from .Saving import *
 
-class QGModel(object):
+class Model(object):
 
     """" Barotropic QG model """
 

--- a/niwqg/tests/test_fft.py
+++ b/niwqg/tests/test_fft.py
@@ -43,7 +43,7 @@ class QGNIWTester(unittest.TestCase):
 class QGTester(unittest.TestCase):
     """ A class for testing the QG model (rffts) """
     def setUp(self):
-        self.m =  QGModel.QGModel(use_filter=False)
+        self.m =  QGModel.Model(use_filter=False)
         self.qi = randn(self.m.ny, self.m.nx)
 
     def test_forward_backward(self, rtol=1e-5):


### PR DESCRIPTION
This renames the QG model class for consistency with class names in the QGNIW Kernel. The test and example were changed accordingly.