### PR TITLE
Adds passive scalar to example

### DIFF
--- a/examples/LambDipole_qg.py
+++ b/examples/LambDipole_qg.py
@@ -39,12 +39,14 @@ path = "128/lamb/moderate_filter"
 m = QGModel.Model(L=L,nx=nx, tmax = tmax,dt = dt, twrite=int(0.1*Te/dt),
                     nu4=7.5e8, use_filter=False,save_to_disk=False,
                     tsave_snapshots=5,path=path,
-                    U =-U, tdiags=1, beta = 0.)
+                    U =-U, tdiags=1, beta = 0.,passive_scalar=True)
 
 #q = McWilliams1984(m,k0=k0,E=U0**2/2)
 q = ic.LambDipole(m, U=U,R = 2*np.pi/k0)
+c = ic.WavePacket(m, k=k0, l=0, R = L/5,x0=L/2,y0=L/2).real
 
 m.set_q(q)
+m.set_c(c)
 
 m._invert()
 


### PR DESCRIPTION
MINOR: Adds passive scalar to Lamb dipole example.

```
crocha (examples) niwqg $ make test
python -m pytest niwqg
============================== test session starts============================
platform darwin -- Python 3.6.0, pytest-3.0.7, py-1.4.32, pluggy-0.4.0
rootdir: /Users/crocha/Projects/niwqg, inifile:
collected 10 items 

niwqg/tests/test_advection.py ..
niwqg/tests/test_diagnostics.py ..
niwqg/tests/test_diffusion.py ..
niwqg/tests/test_fft.py ....

=========================== 10 passed in 7.73 seconds==========================
```