### PR TITLE
Fixes typos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can also run this simple [example](./examples/LambDipole_CoupledModel.ipynb)
 and verify the energy budget.
 
 # Documentation
-Some documentations are available [here](docs/Index.ipynb). Check also the docstrings of
+Some documentation is available [here](docs/Index.ipynb).  Also  check the docstrings of
 classes and methods.`
 
 # Development


### PR DESCRIPTION
MINOR: fix typos.

```python
crocha (docs) niwqg
$ make test
python -m pytest niwqg
================================================= test session starts ==================================================
platform darwin -- Python 3.6.0, pytest-3.0.7, py-1.4.32, pluggy-0.4.0
rootdir: /Users/crocha/Projects/niwqg, inifile:
collected 10 items 

niwqg/tests/test_advection.py ..
niwqg/tests/test_diagnostics.py ..
niwqg/tests/test_diffusion.py ..
niwqg/tests/test_fft.py ....

============================================== 10 passed in 6.79 seconds ===============================================
```