### PR TITLE
Fix conditional saving for QGmodel with passive scalar

### DIFF
--- a/niwqg/Kernel.py
+++ b/niwqg/Kernel.py
@@ -94,7 +94,7 @@ class Kernel(object):
         tsave_snapshots=10,
         tdiags=10,
         path = 'output/',
-        use_mkl=True,
+        use_mkl=False,
         nthreads=1):
 
         self.nx = nx

--- a/niwqg/QGModel.py
+++ b/niwqg/QGModel.py
@@ -193,7 +193,10 @@ class Model(object):
 
         # save initial conditions
         if self.save_to_disk:
-            save_snapshots(self,fields=['t','q','c'])
+            if self.passive_scalar:
+                save_snapshots(self,fields=['t','q','c'])
+            else:
+                save_snapshots(self,fields=['t','q'])
 
         # run the model
         while(self.t < self.tmax):

--- a/niwqg/QGModel.py
+++ b/niwqg/QGModel.py
@@ -87,7 +87,7 @@ class Model(object):
         tsave_snapshots=10,
         tdiags = 10,
         path = 'output/',
-        use_mkl=True,
+        use_mkl=False,
         nthreads=1):
 
         self.nx = nx


### PR DESCRIPTION
This fixes a small bug in `QGmodel` regarding saving when there's no passive scalar field.

```bash
crocha (fix_QG_Saving *) niwqg $ make test
python -m pytest niwqg
========================================== test session starts ==========================================
platform linux -- Python 3.6.0, pytest-3.0.5, py-1.4.32, pluggy-0.4.0
rootdir: /raid/home/crocha/Projects/niwqg, inifile: 
collected 11 items 

niwqg/tests/test_advection.py ..
niwqg/tests/test_diagnostics.py ...
niwqg/tests/test_diffusion.py ..
niwqg/tests/test_fft.py ....

======================================= 11 passed in 9.23 seconds =======================================
```